### PR TITLE
Add support for loose URL handling and loose Absolute URL handling.

### DIFF
--- a/Tokenizer.Tests/SampleTests.cs
+++ b/Tokenizer.Tests/SampleTests.cs
@@ -330,7 +330,7 @@ namespace Tokens
             var result = tokenizer.Tokenize(template, input);
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(51, result.Matches.Count);
+            Assert.AreEqual(52, result.Matches.Count);
 
             var nameServers = result.All("NameServers");
 

--- a/Tokenizer.Tests/Samples/Patterns/whois.generic.txt
+++ b/Tokenizer.Tests/Samples/Patterns/whois.generic.txt
@@ -48,8 +48,8 @@ Registrar IANA ID:{ Registrar.IanaId ? : Trim, IsNumeric, EOL }
 Sponsoring Registrar:{ Registrar.Name ? : Trim, EOL }
 Sponsoring Registrar IANA ID:{ Registrar.IanaId ? : Trim, IsNumeric, EOL }
 WHOIS Server:{ Registrar.WhoisServerUrl ? : Trim, IsDomainName, ToLower, EOL } 
-Referral URL:{ Registrar.Url ? : Trim, IsUrl, ToLower, EOL } 
-Registrar URL:{ Registrar.Url ? : Trim, IsUrl, ToLower, EOL } 
+Referral URL:{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL } 
+Registrar URL:{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL } 
 Domain Status:{ DomainStatus ? : Trim, Repeating, SubstringBefore(' '), EOL }
 Status:{ DomainStatus ? : Trim, Repeating, EOL }
 Registrant ID:{ Registrant.RegistryId ? : Trim, EOL }

--- a/Tokenizer.Tests/Validators/IsLooseAbsoluteUrlValidatorTests.cs
+++ b/Tokenizer.Tests/Validators/IsLooseAbsoluteUrlValidatorTests.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+
+namespace Tokens.Validators
+{
+    [TestFixture]
+    public class IsLooseAbsoluteUrlValidatorTests
+    {
+        private IsLooseAbsoluteUrlValidator validator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            validator = new IsLooseAbsoluteUrlValidator();
+        }
+
+        [Test]
+        public void TestValidateValueWhenHttp()
+        {
+            var result = validator.IsValid("http://github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenHttps()
+        {
+            var result = validator.IsValid("https://github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenNoProtocol()
+        {
+            var result = validator.IsValid("github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenInvalidUrl()
+        {
+            var result = validator.IsValid("hello world");
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenNull()
+        {
+            var result = validator.IsValid(null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenEmpty()
+        {
+            var result = validator.IsValid(string.Empty);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestForDocumentation()
+        {
+            var template = "Server: { ServerUrl : IsUrl, EOL }";
+            var input = "Server: 192.168.1.1\nServer: http://www.server.com";
+
+            var result = new Tokenizer().Tokenize(template, input);
+
+            Assert.AreEqual("http://www.server.com", result.First("ServerUrl"));
+        }
+    }
+}

--- a/Tokenizer.Tests/Validators/IsLooseUrlValidatorTests.cs
+++ b/Tokenizer.Tests/Validators/IsLooseUrlValidatorTests.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+
+namespace Tokens.Validators
+{
+    [TestFixture]
+    public class IsLooseUrlValidatorTests
+    {
+        private IsLooseUrlValidator validator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            validator = new IsLooseUrlValidator();
+        }
+
+        [Test]
+        public void TestValidateValueWhenHttp()
+        {
+            var result = validator.IsValid("http://github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenHttps()
+        {
+            var result = validator.IsValid("https://github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenNoProtocol()
+        {
+            var result = validator.IsValid("github.com");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenInvalidUrl()
+        {
+            var result = validator.IsValid("hello world");
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenNull()
+        {
+            var result = validator.IsValid(null);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestValidateValueWhenEmpty()
+        {
+            var result = validator.IsValid(string.Empty);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestForDocumentation()
+        {
+            var template = "Server: { ServerUrl : IsUrl, EOL }";
+            var input = "Server: 192.168.1.1\nServer: http://www.server.com";
+
+            var result = new Tokenizer().Tokenize(template, input);
+
+            Assert.AreEqual("http://www.server.com", result.First("ServerUrl"));
+        }
+    }
+}

--- a/Tokenizer/Parsers/TokenParser.cs
+++ b/Tokenizer/Parsers/TokenParser.cs
@@ -61,6 +61,8 @@ namespace Tokens.Parsers
             RegisterValidator<IsPhoneNumberValidator>();
             RegisterValidator<IsEmailValidator>();
             RegisterValidator<IsUrlValidator>();
+            RegisterValidator<IsLooseUrlValidator>();
+            RegisterValidator<IsLooseAbsoluteUrlValidator>();
             RegisterValidator<IsDateTimeValidator>();
             RegisterValidator<IsNotEmptyValidator>();
             RegisterValidator<IsNotValidator>();

--- a/Tokenizer/Validators/IsLooseAbsoluteUrlValidator.cs
+++ b/Tokenizer/Validators/IsLooseAbsoluteUrlValidator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Tokens.Validators
+{
+    /// <summary>
+    /// Validator to determine if a token value is a URL
+    /// </summary>
+    public class IsLooseAbsoluteUrlValidator : ITokenValidator
+    {
+        /// <summary>
+        /// Determines whether the specified token is valid.
+        /// </summary>
+        public bool IsValid(object value, params string[] args)
+        {
+            if (value == null) return false;
+
+            var valueString = value.ToString();
+
+            if (string.IsNullOrEmpty(valueString)) return false;
+
+            var result = Uri.IsWellFormedUriString(valueString, UriKind.Absolute);
+
+            if (!result)
+			{
+                result = Uri.IsWellFormedUriString(string.Format("http://{0}", valueString), UriKind.Absolute);
+			}
+
+            return result;
+        }
+    }
+}

--- a/Tokenizer/Validators/IsLooseUrlValidator.cs
+++ b/Tokenizer/Validators/IsLooseUrlValidator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Tokens.Validators
+{
+    /// <summary>
+    /// Validator to determine if a token value is a URL
+    /// </summary>
+    public class IsLooseUrlValidator : ITokenValidator
+    {
+        /// <summary>
+        /// Determines whether the specified token is valid.
+        /// </summary>
+        public bool IsValid(object value, params string[] args)
+        {
+            if (value == null) return false;
+
+            var valueString = value.ToString();
+
+            if (string.IsNullOrEmpty(valueString)) return false;
+
+            var result = Uri.IsWellFormedUriString(valueString, UriKind.RelativeOrAbsolute);
+
+            if (!result)
+			{
+                result = Uri.IsWellFormedUriString(string.Format("http://{0}", valueString), UriKind.RelativeOrAbsolute);
+			}
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Some whois URLs do not contain the protocol in the URL, for example many .CA registrars do not list a protocol in their registrar URL listing.  This update introduces two new validators that can be used to apply a looser check to these fields so that records properly validate.