### PR TITLE
Bump Meziantou.Analyzer from 3.0.125 to 3.0.133

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest-None</AnalysisLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.125">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.133">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Tokenizer.Tests/Compilation/Binders/TemplateFactoryTests.cs
+++ b/tests/Tokenizer.Tests/Compilation/Binders/TemplateFactoryTests.cs
@@ -52,7 +52,7 @@ public class TemplateFactoryTests
         var definition = new TemplateDefinition { Name = string.Empty };
         var t1 = TemplateFactory.Create(1UL, definition);
         var t2 = TemplateFactory.Create(2UL, definition);
-        Assert.NotEqual(t1.Name, t2.Name);
+        Assert.NotEqual(t1.Name, t2.Name, StringComparer.Ordinal);
         Assert.StartsWith("Template_", t1.Name, StringComparison.Ordinal);
         Assert.StartsWith("Template_", t2.Name, StringComparison.Ordinal);
     }

--- a/tests/Tokenizer.Tests/Diagnostics/DiagnosticIntegrationTests.cs
+++ b/tests/Tokenizer.Tests/Diagnostics/DiagnosticIntegrationTests.cs
@@ -142,7 +142,7 @@ public class DiagnosticIntegrationTests : TokenizerTestBase
         var transformerEvent = result.Diagnostics.RawEvents
             .First(e => e.Type == TokenizationEventType.TransformerSucceeded);
         Assert.NotNull(transformerEvent.DecoratorArgs);
-        Assert.Contains("yyyy-MM-dd", transformerEvent.DecoratorArgs);
+        Assert.Contains("yyyy-MM-dd", transformerEvent.DecoratorArgs, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/Tokenizer.Tests/Reflection/PropertyPathSetter.Collections.Tests.cs
+++ b/tests/Tokenizer.Tests/Reflection/PropertyPathSetter.Collections.Tests.cs
@@ -61,7 +61,7 @@ public class PropertyPathSetterCollectionsTests
         _setter.SetCollection(target, "StringList", values, StringComparison.Ordinal);
 
         // Assert
-        Assert.Equal(new[] { "alpha", "beta", "gamma" }, target.StringList);
+        Assert.Equal(new[] { "alpha", "beta", "gamma" }, target.StringList, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -247,7 +247,7 @@ public class PropertyPathSetterCollectionsTests
         _setter.SetCollection(target, "StringList", values, StringComparison.Ordinal);
 
         // Assert
-        Assert.Equal(new[] { "only" }, target.StringList);
+        Assert.Equal(new[] { "only" }, target.StringList, StringComparer.Ordinal);
     }
 
     // ── Getter-only collections ──────────────────────────────────────────────────

--- a/tests/Tokenizer.Tests/Reflection/PropertyPathSetter.Pipeline.Tests.cs
+++ b/tests/Tokenizer.Tests/Reflection/PropertyPathSetter.Pipeline.Tests.cs
@@ -181,7 +181,7 @@ public class PropertyPathSetterPipelineTests : TokenizerTestBase
         var target = result.Assign<CollectionTarget>();
 
         // Assert
-        Assert.Equal(new[] { "tag1", "tag2", "tag3" }, target.Tags);
+        Assert.Equal(new[] { "tag1", "tag2", "tag3" }, target.Tags, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public class PropertyPathSetterPipelineTests : TokenizerTestBase
 
         // Assert
         Assert.Equal("Alice", target.Name);
-        Assert.Equal(new[] { "dev", "ops" }, target.Tags);
+        Assert.Equal(new[] { "dev", "ops" }, target.Tags, StringComparer.Ordinal);
     }
 
     // ── Missing property tests ──────────────────────────────────────────────────

--- a/tests/Tokenizer.Tests/TemplateCollectionTests.cs
+++ b/tests/Tokenizer.Tests/TemplateCollectionTests.cs
@@ -140,7 +140,7 @@ public class TemplateCollectionTests : TokenizerTestBase
         var names = coll.Select(t => t.Name).Order(StringComparer.Ordinal).ToList();
 
         // Assert
-        Assert.Equal(new[] { "alpha", "beta" }, names);
+        Assert.Equal(new[] { "alpha", "beta" }, names, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/Tokenizer.Tests/Temporal/DatePatternRecognizerTests.cs
+++ b/tests/Tokenizer.Tests/Temporal/DatePatternRecognizerTests.cs
@@ -148,7 +148,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy.MM.dd HH:mm:ss", f);
+        Assert.Contains("yyyy.MM.dd HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -167,7 +167,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy-MM-dd HH:mm:ss", f);
+        Assert.Contains("yyyy-MM-dd HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -187,7 +187,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd-MMM-yyyy HH:mm:ss", f);
+        Assert.Contains("dd-MMM-yyyy HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -207,7 +207,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dddd d MMMM yyyy", f);
+        Assert.Contains("dddd d MMMM yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -227,7 +227,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd MMM yyyy HH:mmzzz", f);
+        Assert.Contains("dd MMM yyyy HH:mmzzz", f, StringComparer.Ordinal);
         Assert.True(DateTimeOffset.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -247,7 +247,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("MMMM d, yyyy", f);
+        Assert.Contains("MMMM d, yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -268,7 +268,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd-MMM-yyyy", f);
+        Assert.Contains("dd-MMM-yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -288,7 +288,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd MMM yyyy", f);
+        Assert.Contains("dd MMM yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -308,7 +308,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd-MMMM-yyyy", f);
+        Assert.Contains("dd-MMMM-yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -327,7 +327,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd.MM.yyyy HH:mm:ss", f);
+        Assert.Contains("dd.MM.yyyy HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -367,7 +367,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy. MM. dd.", f);
+        Assert.Contains("yyyy. MM. dd.", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -387,7 +387,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy-MMM-dd.", f);
+        Assert.Contains("yyyy-MMM-dd.", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -406,7 +406,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy/MM/dd HH:mm:ss", f);
+        Assert.Contains("yyyy/MM/dd HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -425,7 +425,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd/MM/yyyy HH:mm:ss", f);
+        Assert.Contains("dd/MM/yyyy HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -444,7 +444,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy-MM-dd", f);
+        Assert.Contains("yyyy-MM-dd", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -463,7 +463,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy.MM.dd", f);
+        Assert.Contains("yyyy.MM.dd", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -482,7 +482,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy/MM/dd", f);
+        Assert.Contains("yyyy/MM/dd", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -501,7 +501,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd.MM.yyyy", f);
+        Assert.Contains("dd.MM.yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -520,7 +520,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd/MM/yyyy", f);
+        Assert.Contains("dd/MM/yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -539,7 +539,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd-MM-yyyy", f);
+        Assert.Contains("dd-MM-yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -558,7 +558,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyyMMddHHmmss", f);
+        Assert.Contains("yyyyMMddHHmmss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -577,7 +577,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyyMMdd HH:mm:ss", f);
+        Assert.Contains("yyyyMMdd HH:mm:ss", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -596,7 +596,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyyMMdd", f);
+        Assert.Contains("yyyyMMdd", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -616,7 +616,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("d.M.yyyy", f);
+        Assert.Contains("d.M.yyyy", f, StringComparer.Ordinal);
         Assert.True(DateTime.TryParseExact(input, f, CultureInfo.InvariantCulture,
             DateTimeStyles.None, out _), $"TryParseExact failed for '{input}' with formats [{string.Join(", ", f)}]");
     }
@@ -637,7 +637,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("dd/MM/yyyy", f);
+        Assert.Contains("dd/MM/yyyy", f, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -649,7 +649,7 @@ public class DatePatternRecognizerTests
         // Assert
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("MM/dd/yyyy", f);
+        Assert.Contains("MM/dd/yyyy", f, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -706,6 +706,6 @@ public class DatePatternRecognizerTests
 
         Assert.True(result);
         var f = formats!;
-        Assert.Contains("yyyy-MM-ddTHH:mm:sszzz", f);
+        Assert.Contains("yyyy-MM-ddTHH:mm:sszzz", f, StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `Meziantou.Analyzer` from 3.0.125 to 3.0.133 in `Directory.Build.props`
- Fixes 34 new MA0002 violations (the upgraded analyser now flags string comparisons without an explicit comparer)
- All fixes are in test files only - the source project built clean with zero violations

The fixes add `StringComparer.Ordinal` to `Assert.Equal`, `Assert.NotEqual` and `Assert.Contains` calls that compare strings or string collections. Purely mechanical, no behaviour changes.

## Test plan

- [x] `dotnet build ./Tokenizer.sln -c Release` passes with 0 warnings, 0 errors
- [x] `dotnet test` passes all 1762 tests