### PR TITLE
Group dependabot updates and bump all outstanding dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    all-nuget-updates:
+      patterns:
+        - "*"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest-None</AnalysisLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.137">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.172">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tokenizer/Tokenizer.csproj
+++ b/src/Tokenizer/Tokenizer.csproj
@@ -17,9 +17,9 @@
    <PackageIcon>icon.png</PackageIcon>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
   
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,6 +47,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
-    <PackageReference Include="System.IO.Hashing" Version="10.0.10" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.11" />
   </ItemGroup>
 </Project>

--- a/tests/Tokenizer.Tests/Tokenizer.Tests.csproj
+++ b/tests/Tokenizer.Tests/Tokenizer.Tests.csproj
@@ -9,19 +9,19 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
     <PackageReference Include="Serilog" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Brought the dependabot config in line with the whois project - weekly runs on Monday mornings instead of daily, and all NuGet updates grouped into a single PR. Should cut down on the noise from individual version bump PRs piling up.

Also rolled in the outstanding version bumps from the 7 open dependabot PRs (#120, #124, #126, #128, #132, #133, #136), so those can be closed once this merges.

**Dependency updates:**

| Package | From | To |
|---------|------|----|
| Meziantou.Analyzer | 3.0.137 | 3.0.172 |
| Microsoft.Extensions.DependencyInjection | 9.0.10 | 10.0.11 |
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.9 | 10.0.11 |
| Microsoft.Extensions.Logging | 8.0.0 | 10.0.11 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.9 | 10.0.11 |
| Microsoft.Extensions.Options | 8.0.0 | 10.0.11 |
| Microsoft.Extensions.Configuration | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Configuration.Json | 10.0.10 | 10.0.11 |
| Microsoft.NET.Test.Sdk | 18.8.1 | 18.9.0 |
| Microsoft.SourceLink.GitHub | 10.0.301 | 10.0.400 |
| System.IO.Hashing | 10.0.10 | 10.0.11 |
| xunit.runner.visualstudio | 3.1.5 | 4.0.0 |

## Test plan

- [x] All 1762 tests pass
- [ ] CI build passes
- [ ] Close superseded dependabot PRs (#120, #124, #126, #128, #132, #133, #136) after merge